### PR TITLE
Bugfix/IMX-2711-disable-analytics-events-during-tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ class ImxLinkController {
     console.log("imxlinkPages", imxlinkPages);
     console.assert(imxlinkPages.length === 1, "Couldn't find IMX Link page!");
 
-    return imxlinkPages[0];
+    const imxLinkPage = imxlinkPages[0];
+    await imxLinkPage.evaluateOnNewDocument((envData) => {
+      window.appEnvironment = { ...envData };
+    }, { NODE_ENV = "test" });
+    return imxLinkPage;
   }
 
   async listAsset() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "link-puppeteer",
-  "version": "2.6.0",
+  "version": "2.6.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
-----------------------------------------
Cards Progressed
-----------------------------------------

- **[IMX-2711](https://immutable.atlassian.net/browse/IMX-2711):** Analytics events are triggered for Link while running the CY e2e tests

----------------------------------------
Block analytics events in 'e2e' tests
----------------------------------------

- **[IMX-2775](https://immutable.atlassian.net/browse/IMX-2775):** Added 'window' variable in 'LINK-puppeteer' to load within the Link tests.